### PR TITLE
[design] 홈 페이지 퍼블리싱 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*.local
+.env*
 
 # vercel
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env*.local
 .env*
 
 # vercel

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.15.15",
     "@mui/material": "^5.15.15",
+    "daisyui": "^4.10.2",
     "msw": "^2.2.13",
     "next": "14.1.3",
     "next-fonts": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "next": "14.1.3",
     "next-fonts": "^1.5.1",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-kakao-maps-sdk": "^1.1.26"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.0.2",
     "@eslint/js": "^9.0.0",
+    "@types/navermaps": "^3.7.5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/components/footer.tsx
+++ b/src/app/components/footer.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { Montserrat } from 'next/font/google';
+import ignorePath from '../styles/ignorePath.ts';
+
+const mont = Montserrat({ subsets: ['latin'], weight: ['500'] });
+
+function Footer() {
+  const path = usePathname();
+  if (ignorePath().includes(path)) {
+    return null;
+  }
+  return (
+    <div className="flex flex-col mt-20 pl-64 justify-center bg-zinc-200 w-full h-60">
+      <h1 className={mont.className}>
+        <span className="text-2xl">MOITDA</span>
+      </h1>
+      <br />
+      모임을 만들고 <br />
+      잇다 <br />
+      간편 만남 서비스, 모잇다
+    </div>
+  );
+}
+
+export default Footer;

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -14,6 +14,7 @@ import { SetStateAction, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import theme from '../styles/muiTheme.ts';
+import ignorePath from '../styles/ignorePath.ts';
 
 const mont = Montserrat({ subsets: ['latin'], weight: ['500'] });
 
@@ -27,7 +28,7 @@ function Header() {
   const path = usePathname();
 
   // 만약 로그인 페이지이면 Header를 숨깁니다.
-  if (path === '/login' || path === '/signup' || path === '/introduce') {
+  if (ignorePath().includes(path)) {
     return null;
   }
 

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -18,7 +18,7 @@ import theme from '../styles/muiTheme.ts';
 const mont = Montserrat({ subsets: ['latin'], weight: ['500'] });
 
 function Header() {
-  const [isLogin, setIsLogin] = useState(false);
+  const [isLogin] = useState(false);
   const [openMenu, setOpenMenu] = useState(false);
   const [openCategories, setOpenCategories] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');

--- a/src/app/components/postComponent.tsx
+++ b/src/app/components/postComponent.tsx
@@ -1,3 +1,38 @@
-const postComponent = () => <div>postComponent입니다.</div>;
+/* eslint-disable object-curly-newline */
 
-export default postComponent;
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { postProps } from '../../types/post.ts';
+
+function PostComponent({ titleImage, title, location, like }: postProps) {
+  return (
+    <Link
+      className="flex flex-col justify-center m-4 cursor-pointer"
+      href={`/meetingdetails/${title}`}
+    >
+      <div className="flex w-56 h-56">
+        <Image
+          src={titleImage}
+          alt={titleImage}
+          className="relative object-cover rounded-lg"
+          width={10000}
+          height={10000}
+          //   layout="responsive"
+        />
+      </div>
+      <p className="text-lg font-bold pt-1">{title}</p>
+      <p className="text-sm">{location}</p>
+
+      <div className="flex flex-row items-center">
+        <svg className="w-4 h-4 text-red-300 fill-current" viewBox="0 0 24 24">
+          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+        </svg>
+        <p className="text-sm pl-1">{like}</p>
+      </div>
+    </Link>
+  );
+}
+
+export default PostComponent;

--- a/src/app/home/distanceComponent.tsx
+++ b/src/app/home/distanceComponent.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable operator-linebreak */
+/* eslint-disable @next/next/no-sync-scripts */
+
+'use client';
+
+import Script from 'next/script';
+import { Map } from 'react-kakao-maps-sdk';
+
+function DistanceComponent() {
+  return (
+    <div className="flex flex-col w-full h-full">
+      <div className="w-96 h-96" id="map">
+        <Script
+          src={process.env.NEXT_PUBLIC_KAKAO_SDK_URL}
+          strategy="beforeInteractive"
+        />
+        <Map
+          center={{ lat: 33.450701, lng: 126.570667 }}
+          style={{ width: '100%', height: '100%' }}
+        ></Map>
+        asdf
+      </div>
+    </div>
+  );
+}
+
+export default DistanceComponent;

--- a/src/app/home/distanceComponent.tsx
+++ b/src/app/home/distanceComponent.tsx
@@ -5,20 +5,46 @@
 
 import Script from 'next/script';
 import { Map } from 'react-kakao-maps-sdk';
+import Image from 'next/image'; // Import the Image component
 
 function DistanceComponent() {
   return (
     <div className="flex flex-col w-full h-full">
-      <div className="w-96 h-96" id="map">
-        <Script
-          src={process.env.NEXT_PUBLIC_KAKAO_SDK_URL}
-          strategy="beforeInteractive"
-        />
-        <Map
-          center={{ lat: 33.450701, lng: 126.570667 }}
-          style={{ width: '100%', height: '100%' }}
-        ></Map>
-        asdf
+      <div className="flex flex-row justify-center items-center">
+        <div className="flex flex-col w-60 h-[28rem] border m-4 border-zinc-300">
+          <div className="flex w-60 h-60">
+            <Image
+              src="https://i.ibb.co/0GtvPDT/Kakao-Talk-Photo-2024-04-17-21-26-58.jpg"
+              width={1000}
+              height={1000}
+              className="relative object-cover"
+              alt="Image"
+            />
+          </div>
+          <div className="flex flex-col h-full justify-around p-2 py-8">
+            {' '}
+            <p className="text-lg font-bold">4월 8일 월요일 16:00</p>
+            <p className="text-xl">모각코 할 사람!</p>
+            <p className="text-sm text-zinc-400">
+              경기 수원시 장안구 경수대로 831
+            </p>
+            <p className="text-sm text-zinc-400">(스타벅스 수원조원 DT점)</p>
+            <p className="text-sm text-zinc-400">#공부</p>
+          </div>
+        </div>
+        <div
+          className="w-[50rem] h-[28rem] border border-zinc-300 m-4"
+          id="map"
+        >
+          <Script
+            src={process.env.NEXT_PUBLIC_KAKAO_SDK_URL}
+            strategy="beforeInteractive"
+          />
+          <Map
+            center={{ lat: 33.450701, lng: 126.570667 }}
+            style={{ width: '100%', height: '100%' }}
+          ></Map>
+        </div>
       </div>
     </div>
   );

--- a/src/app/home/homeBodyComponent.tsx
+++ b/src/app/home/homeBodyComponent.tsx
@@ -8,7 +8,7 @@ import LatestComponent from './latestComponent.tsx';
 import DistanceComponent from './distanceComponent.tsx';
 
 function HomeBodyComponent() {
-  const [activeTab, setActiveTab] = useState<string>('distance');
+  const [activeTab, setActiveTab] = useState<string>('latest');
   const [selectedTheme, setSelectedTheme] = useState<string>('지역 검색');
 
   const cityList = [
@@ -44,14 +44,14 @@ function HomeBodyComponent() {
   const mainBody = () => {
     if (activeTab === 'latest') {
       return (
-        <div>
+        <div className="flex justify-center items-center w-full">
           <LatestComponent />
         </div>
       );
     }
     if (activeTab === 'distance') {
       return (
-        <div>
+        <div className="flex justify-center items-center w-full">
           <DistanceComponent />
         </div>
       );
@@ -120,6 +120,10 @@ function HomeBodyComponent() {
       </div>
       <div className="flex flex-col justify-start items-start w-full h-full">
         {mainBody()}
+        {/* 강제로 지도 컴포넌트 렌더링 */}
+        <div className="w-0 h-0 overflow-hidden">
+          <DistanceComponent />
+        </div>
       </div>
     </div>
   );

--- a/src/app/home/homeBodyComponent.tsx
+++ b/src/app/home/homeBodyComponent.tsx
@@ -5,9 +5,10 @@
 
 import { useState } from 'react';
 import LatestComponent from './latestComponent.tsx';
+import DistanceComponent from './distanceComponent.tsx';
 
 function HomeBodyComponent() {
-  const [activeTab, setActiveTab] = useState<string>('latest');
+  const [activeTab, setActiveTab] = useState<string>('distance');
   const [selectedTheme, setSelectedTheme] = useState<string>('지역 검색');
 
   const cityList = [
@@ -49,7 +50,11 @@ function HomeBodyComponent() {
       );
     }
     if (activeTab === 'distance') {
-      return <div>거리</div>;
+      return (
+        <div>
+          <DistanceComponent />
+        </div>
+      );
     }
   };
 
@@ -65,7 +70,7 @@ function HomeBodyComponent() {
             className={`tab ${activeTab === 'latest' ? 'font-bold' : ''}`}
             aria-label="최신순"
             checked={activeTab === 'latest'}
-            onClick={() => handleTabClick('latest')}
+            onChange={() => handleTabClick('latest')}
           />
 
           <input
@@ -75,7 +80,7 @@ function HomeBodyComponent() {
             className={`tab ${activeTab === 'distance' ? 'font-bold' : ''}`}
             aria-label="거리순"
             checked={activeTab === 'distance'}
-            onClick={() => handleTabClick('distance')}
+            onChange={() => handleTabClick('distance')}
           />
         </div>
 

--- a/src/app/home/homeBodyComponent.tsx
+++ b/src/app/home/homeBodyComponent.tsx
@@ -4,6 +4,7 @@
 'use client';
 
 import { useState } from 'react';
+import LatestComponent from './latestComponent.tsx';
 
 function HomeBodyComponent() {
   const [activeTab, setActiveTab] = useState<string>('latest');
@@ -41,7 +42,11 @@ function HomeBodyComponent() {
 
   const mainBody = () => {
     if (activeTab === 'latest') {
-      return <div>최신</div>;
+      return (
+        <div>
+          <LatestComponent />
+        </div>
+      );
     }
     if (activeTab === 'distance') {
       return <div>거리</div>;

--- a/src/app/home/homeBodyComponent.tsx
+++ b/src/app/home/homeBodyComponent.tsx
@@ -89,7 +89,7 @@ function HomeBodyComponent() {
               </div>
               <ul
                 tabIndex={0}
-                className="dropdown-content z-[1] p-2 shadow-2xl bg-base-300 rounded-box w-52"
+                className="dropdown-content z-[1] p-2 shadow-2xl bg-base-200 rounded-box w-52"
               >
                 {cityList.map((district, index) => (
                   <li key={`${index}`}>

--- a/src/app/home/homeBodyComponent.tsx
+++ b/src/app/home/homeBodyComponent.tsx
@@ -1,0 +1,118 @@
+// 메인페이지 홈 바디 컴포넌트
+/* eslint-disable consistent-return */
+
+'use client';
+
+import { useState } from 'react';
+
+function HomeBodyComponent() {
+  const [activeTab, setActiveTab] = useState<string>('latest');
+  const [selectedTheme, setSelectedTheme] = useState<string>('지역 검색');
+
+  const cityList = [
+    '모든 지역',
+    '서울',
+    '경기',
+    '인천',
+    '강원',
+    '대전/세종',
+    '충남',
+    '충북',
+    '대구',
+    '경북',
+    '부산',
+    '울산',
+    '경남',
+    '광주',
+    '전남',
+    '전북',
+    '제주',
+  ];
+
+  const handleTabClick = (tabName: string) => {
+    if (activeTab !== tabName) {
+      setActiveTab(tabName);
+    }
+  };
+
+  const handleThemeChange = (event: any) => {
+    setSelectedTheme(event.target.value);
+  };
+
+  const mainBody = () => {
+    if (activeTab === 'latest') {
+      return <div>최신</div>;
+    }
+    if (activeTab === 'distance') {
+      return <div>거리</div>;
+    }
+  };
+
+  return (
+    <div className="flex flex-col w-full h-full">
+      <div className="flex flex-row justify-start items-start w-full p-12">
+        {/* 탭 리스트 */}
+        <div role="tablist" className="tabs tabs-bordered tabs-lg w-1/4">
+          <input
+            type="radio"
+            name="latestTab"
+            role="tab"
+            className={`tab ${activeTab === 'latest' ? 'font-bold' : ''}`}
+            aria-label="최신순"
+            checked={activeTab === 'latest'}
+            onClick={() => handleTabClick('latest')}
+          />
+
+          <input
+            type="radio"
+            name="distanceTab"
+            role="tab"
+            className={`tab ${activeTab === 'distance' ? 'font-bold' : ''}`}
+            aria-label="거리순"
+            checked={activeTab === 'distance'}
+            onClick={() => handleTabClick('distance')}
+          />
+        </div>
+
+        {/* 지역 검색 드롭다운 */}
+        <div className="flex flex-row justify-end items-center w-full">
+          {activeTab === 'latest' && (
+            <div className="dropdown dropdown-bottom dropdown-end">
+              <div tabIndex={0} role="button" className="btn">
+                {selectedTheme}
+                <svg
+                  className="h-2 w-2 fill-current opacity-60 inline-block"
+                  viewBox="0 0 2048 2048"
+                >
+                  <path d="M1799 349l242 241-1017 1017L7 590l242-241 775 775 775-775z" />
+                </svg>
+              </div>
+              <ul
+                tabIndex={0}
+                className="dropdown-content z-[1] p-2 shadow-2xl bg-base-300 rounded-box w-52"
+              >
+                {cityList.map((district, index) => (
+                  <li key={`${index}`}>
+                    <input
+                      type="radio"
+                      name="theme-dropdown"
+                      className="theme-controller btn btn-sm btn-block btn-ghost justify-start"
+                      aria-label={`${district}`}
+                      value={`${district}`}
+                      onChange={handleThemeChange}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="flex flex-col justify-start items-start w-full h-full">
+        {mainBody()}
+      </div>
+    </div>
+  );
+}
+
+export default HomeBodyComponent;

--- a/src/app/home/homeHeaderComponent.tsx
+++ b/src/app/home/homeHeaderComponent.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-// 메인 페이지 상단 홈 컴포넌트
+// 메인 페이지 홈 헤더 컴포넌트
 
 'use client';
 
@@ -7,9 +7,9 @@ import { ThemeProvider } from '@emotion/react';
 import { IconButton } from '@mui/material';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import { useState } from 'react';
-import theme from './styles/muiTheme.ts';
+import theme from '../styles/muiTheme.ts';
 
-function HomeMainComponent() {
+function HomeHeaderComponent() {
   const [pageIndex, setPageIndex] = useState(1);
   const [maxPageIndex] = useState(4);
 
@@ -62,4 +62,4 @@ function HomeMainComponent() {
   );
 }
 
-export default HomeMainComponent;
+export default HomeHeaderComponent;

--- a/src/app/home/homeHeaderComponent.tsx
+++ b/src/app/home/homeHeaderComponent.tsx
@@ -3,11 +3,7 @@
 
 'use client';
 
-import { ThemeProvider } from '@emotion/react';
-import { IconButton } from '@mui/material';
-import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import { useState } from 'react';
-import theme from '../styles/muiTheme.ts';
 
 function HomeHeaderComponent() {
   const [pageIndex, setPageIndex] = useState(1);
@@ -26,39 +22,44 @@ function HomeHeaderComponent() {
   };
 
   return (
-    <ThemeProvider theme={theme}>
-      <div className="flex flex-row w-full h-96 justify-center items-center bg-black opacity-90 relative overflow-hidden">
-        <img
-          src="https://i.ibb.co/wL61Zx5/home-Image.png"
-          alt="home-Image"
-          className="w-full absolute"
-        />
-        <div className="flex w-1/6 h-full justify-center items-center z-0">
-          <IconButton
-            className="bg-white bg-opacity-10"
-            onClick={handleBackwardClick}
+    <div className="flex flex-row w-full h-96 justify-center items-center bg-black opacity-90 relative overflow-hidden">
+      <img
+        src="https://i.ibb.co/wL61Zx5/home-Image.png"
+        alt="home-Image"
+        className="w-full absolute"
+      />
+      <div className="flex w-1/6 h-full justify-center items-center z-0">
+        <button
+          className="btn btn-circle bg-black bg-opacity-20 text-white border-none hover:bg-zinc-800"
+          onClick={handleBackwardClick}
+        >
+          <svg
+            className="h-6 w-6 transform rotate-180"
+            fill="none"
+            stroke="currentColor"
           >
-            <ArrowBackIosNewIcon color="primary" fontSize="large" />
-          </IconButton>
-        </div>
-        <div className="flex flex-col w-4/6 h-full justify-center z-0">
-          <p className="text-white text-4xl p-2">모임을 만들고</p>
-          <p className="text-white text-4xl font-bold p-2">잇다</p>
-          <p className="text-white text-2xl p-2">
-            간편 만남 서비스, <span className="font-bold">모잇다</span>
-          </p>
-        </div>
-        <div className="flex w-1/6 h-full justify-center items-center z-0">
-          {' '}
-          <IconButton
-            className="bg-white bg-opacity-10 rotate-180"
-            onClick={handleForwardClick}
-          >
-            <ArrowBackIosNewIcon color="primary" fontSize="large" />
-          </IconButton>
-        </div>
+            <path strokeWidth="2" d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
       </div>
-    </ThemeProvider>
+      <div className="flex flex-col w-4/6 h-full justify-center z-0">
+        <p className="text-white text-4xl p-2">모임을 만들고</p>
+        <p className="text-white text-4xl font-bold p-2">잇다</p>
+        <p className="text-white text-2xl p-2">
+          간편 만남 서비스, <span className="font-bold">모잇다</span>
+        </p>
+      </div>
+      <div className="flex w-1/6 h-full justify-center items-center z-0">
+        <button
+          className="btn btn-circle bg-black bg-opacity-20 text-white border-none hover:bg-zinc-800"
+          onClick={handleForwardClick}
+        >
+          <svg className="h-6 w-6 transform" fill="none" stroke="currentColor">
+            <path strokeWidth="2" d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/src/app/home/latestComponent.tsx
+++ b/src/app/home/latestComponent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PostComponent from '../components/postComponent.tsx';
 
 function LatestComponent() {
@@ -7,6 +6,7 @@ function LatestComponent() {
   for (let i = 0; i < 32; i += 1) {
     postList.push(
       <PostComponent
+        key={i}
         titleImage="https://i.ibb.co/0GtvPDT/Kakao-Talk-Photo-2024-04-17-21-26-58.jpg"
         title="모각코 할 사람!"
         location="서울"

--- a/src/app/home/latestComponent.tsx
+++ b/src/app/home/latestComponent.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PostComponent from '../components/postComponent.tsx';
+
+function LatestComponent() {
+  const postList = [];
+
+  for (let i = 0; i < 32; i += 1) {
+    postList.push(
+      <PostComponent
+        titleImage="https://i.ibb.co/0GtvPDT/Kakao-Talk-Photo-2024-04-17-21-26-58.jpg"
+        title="모각코 할 사람!"
+        location="서울"
+        like={10}
+      />,
+    );
+  }
+
+  return <div className="flex flex-row items-center flex-wrap">{postList}</div>;
+}
+
+export default LatestComponent;

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -9,7 +9,7 @@ async function page() {
   return (
     <div className="flex flex-col justify-center items-center w-full h-full">
       <HomeHeaderComponent />
-      <div className="flex flex-col justify-center items-center w-4/6 h-full">
+      <div className="flex flex-col justify-center items-center w-[67.5rem] h-full">
         <HomeBodyComponent />
       </div>
     </div>

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,19 @@
+// 홈 페이지 컴포넌트
+
+'use server';
+
+import HomeHeaderComponent from './homeHeaderComponent.tsx';
+import HomeBodyComponent from './homeBodyComponent.tsx';
+
+async function page() {
+  return (
+    <div className="flex flex-col justify-center items-center w-full h-full">
+      <HomeHeaderComponent />
+      <div className="flex flex-col justify-center items-center w-4/6 h-full">
+        <HomeBodyComponent />
+      </div>
+    </div>
+  );
+}
+
+export default page;

--- a/src/app/homeMainComponent.tsx
+++ b/src/app/homeMainComponent.tsx
@@ -1,0 +1,65 @@
+/* eslint-disable @next/next/no-img-element */
+// 메인 페이지 상단 홈 컴포넌트
+
+'use client';
+
+import { ThemeProvider } from '@emotion/react';
+import { IconButton } from '@mui/material';
+import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
+import { useState } from 'react';
+import theme from './styles/muiTheme.ts';
+
+function HomeMainComponent() {
+  const [pageIndex, setPageIndex] = useState(1);
+  const [maxPageIndex] = useState(4);
+
+  const handleForwardClick = () => {
+    if (pageIndex < maxPageIndex) {
+      setPageIndex(pageIndex + 1);
+    }
+  };
+
+  const handleBackwardClick = () => {
+    if (pageIndex > 1) {
+      setPageIndex(pageIndex - 1);
+    }
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <div className="flex flex-row w-full h-96 justify-center items-center bg-black opacity-90 relative overflow-hidden">
+        <img
+          src="https://i.ibb.co/wL61Zx5/home-Image.png"
+          alt="home-Image"
+          className="w-full absolute"
+        />
+        <div className="flex w-1/6 h-full justify-center items-center z-0">
+          <IconButton
+            className="bg-white bg-opacity-10"
+            onClick={handleBackwardClick}
+          >
+            <ArrowBackIosNewIcon color="primary" fontSize="large" />
+          </IconButton>
+        </div>
+        <div className="flex flex-col w-4/6 h-full justify-center z-0">
+          <p className="text-white text-4xl p-2">모임을 만들고</p>
+          <p className="text-white text-4xl font-bold p-2">잇다</p>
+          <p className="text-white text-2xl p-2">
+            간편 만남 서비스, <span className="font-bold">모잇다</span>
+          </p>
+        </div>
+        <div className="flex w-1/6 h-full justify-center items-center z-0">
+          {' '}
+          <IconButton
+            className="bg-white bg-opacity-10 rotate-180"
+            onClick={handleForwardClick}
+          >
+            <ArrowBackIosNewIcon color="primary" fontSize="large" />
+          </IconButton>
+        </div>
+      </div>
+    </ThemeProvider>
+  );
+}
+
+export default HomeMainComponent;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './styles/globals.css';
 import Header from './components/header.tsx';
+import Footer from './components/footer.tsx';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -22,6 +23,7 @@ export default function RootLayout({
         <link rel="icon" href="https://i.ibb.co/kyrZGk4/fhrh.png" sizes="any" />
         <Header />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,11 +2,14 @@
 
 'use server';
 
-import HomeMainComponent from './homeMainComponent.tsx';
+import Link from 'next/link';
 
 const Home = async () => (
   <div>
-    <HomeMainComponent />
+    <h1 className="text-2xl">Moitda 프로젝트입니다.</h1>
+    <Link className="text-blue-600" href="/home">
+      home으로 가기
+    </Link>
   </div>
 );
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,12 @@
+// 메인 페이지 컴포넌트
+
 'use server';
+
+import HomeMainComponent from './homeMainComponent.tsx';
 
 const Home = async () => (
   <div>
-    <h1>Moitda 프로젝트입니다.</h1>
+    <HomeMainComponent />
   </div>
 );
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,18 @@
 // 메인 페이지 컴포넌트
 
-'use server';
+'use client';
 
 import Link from 'next/link';
 
-const Home = async () => (
-  <div className="flex flex-col w-full h-screen">
-    <h1 className="text-2xl">Moitda 프로젝트입니다.</h1>
-    <Link className="text-blue-600" href="/home">
-      home으로 가기
-    </Link>
-  </div>
-);
+function Home() {
+  return (
+    <div className="flex flex-col w-full h-screen">
+      <h1 className="text-2xl">Moitda 프로젝트입니다.</h1>
+      <Link className="text-blue-600" href="/home">
+        home으로 가기
+      </Link>
+    </div>
+  );
+}
 
 export default Home;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@
 import Link from 'next/link';
 
 const Home = async () => (
-  <div>
+  <div className="flex flex-col w-full h-screen">
     <h1 className="text-2xl">Moitda 프로젝트입니다.</h1>
     <Link className="text-blue-600" href="/home">
       home으로 가기

--- a/src/app/styles/ignorePath.ts
+++ b/src/app/styles/ignorePath.ts
@@ -1,0 +1,2 @@
+const ignorePath = () => ['/introduce', '/login', '/signup'];
+export default ignorePath;

--- a/src/app/styles/muiTheme.ts
+++ b/src/app/styles/muiTheme.ts
@@ -8,7 +8,7 @@ const theme = createTheme({
     },
     // 2순위 컬러(보조 색)
     secondary: {
-      main: '#ffffff',
+      main: '#000000',
     },
   },
 });

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,4 +1,4 @@
-export interface Post {
+export interface postProps {
   titleImage: string;
   title: string;
   location: string;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,20 +1,20 @@
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss';
 
 const config: Config = {
   content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {
       backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+        'gradient-conic':
+          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
     },
   },
-  plugins: [],
+  plugins: [require('daisyui')],
 };
 export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable global-require */
 import type { Config } from 'tailwindcss';
 
 const config: Config = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,6 +1306,14 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-selector-tokenizer@^0.8:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz#88267ef6238e64f2215ea2764b3e2cf498b845dd"
+  integrity sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==
+  dependencies:
+    cssesc "^3.0.0"
+    fastparse "^1.1.2"
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -1315,6 +1323,21 @@ csstype@^3.0.2, csstype@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
+culori@^3:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/culori/-/culori-3.3.0.tgz#e33530adbd124d53bd6550394397e695eaaed739"
+  integrity sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==
+
+daisyui@^4.10.2:
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/daisyui/-/daisyui-4.10.2.tgz#c0e072b94ccaa0326d1fdec26e8dc163ac070561"
+  integrity sha512-eCWS1W/JPyxW9IvlgW5m0R6rp9ZhRsBTW37rvEUthckkjsV04u8XipV519OoccSA46ixhSJa3q7XLI1WUFtRCA==
+  dependencies:
+    css-selector-tokenizer "^0.8"
+    culori "^3"
+    picocolors "^1"
+    postcss-js "^4"
 
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
@@ -1992,6 +2015,11 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fastparse@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
+  integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
 
 fastq@^1.6.0:
   version "1.17.1"
@@ -3031,7 +3059,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-picocolors@^1.0.0:
+picocolors@^1, picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
@@ -3065,7 +3093,7 @@ postcss-import@^15.1.0:
     read-cache "^1.0.0"
     resolve "^1.1.7"
 
-postcss-js@^4.0.1:
+postcss-js@^4, postcss-js@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-4.0.1.tgz#61598186f3703bab052f1c4f7d805f3991bee9d2"
   integrity sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,7 +47,7 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.23.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.22.15", "@babel/runtime@^7.23.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.24.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.4.tgz#de795accd698007a66ba44add6cc86542aff1edd"
   integrity sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==
@@ -601,6 +601,11 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
   integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
+"@types/geojson@*":
+  version "7946.0.14"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.14.tgz#319b63ad6df705ee2a65a73ef042c8271e696613"
+  integrity sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==
+
 "@types/json-schema@^7.0.15", "@types/json-schema@^7.0.8":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -617,6 +622,13 @@
   integrity sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==
   dependencies:
     "@types/node" "*"
+
+"@types/navermaps@^3.7.5":
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/@types/navermaps/-/navermaps-3.7.5.tgz#70289227d50a6755268679d55ac0ecbe1f497d98"
+  integrity sha512-RzqYi0K5xhs45+KLkeoWjz2niDjVwKMYS1/LKns2LH9L7LEMVabdmyhP7n/6fzdJnbHc1wD1Dz+lFKOgq4yzJQ==
+  dependencies:
+    "@types/geojson" "*"
 
 "@types/node@*", "@types/node@^20.12.4":
   version "20.12.7"
@@ -2647,6 +2659,11 @@ json5@^2.1.2:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+kakao.maps.d.ts@^0.1.39:
+  version "0.1.39"
+  resolved "https://registry.yarnpkg.com/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.39.tgz#dc30726531906d9c42b8f15d7404baa169b8255e"
+  integrity sha512-KXENJ8hHYtjb5G+0vf8TXx/PwWW4j5ndDiQTSMvGtF7EFWu2P3N/+Zivcj9/UKn3j29Iz/sIUaA7WL8Ug3IDGQ==
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -3199,6 +3216,14 @@ react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-kakao-maps-sdk@^1.1.26:
+  version "1.1.26"
+  resolved "https://registry.yarnpkg.com/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.26.tgz#5326e670300e8830e138f1e4b5a8db208d9bc27a"
+  integrity sha512-rzQLGVPk8LmT8ffZFiPEutQxxufH/K9ffbFgCnE9OqqfvlQ94qmBtl8s5MvTtt3noOJ3W1WBTle1B/Y+Yphuug==
+  dependencies:
+    "@babel/runtime" "^7.22.15"
+    kakao.maps.d.ts "^0.1.39"
 
 react-transition-group@^4.4.5:
   version "4.4.5"


### PR DESCRIPTION
### 🚀 Summary

홈 페이지 퍼블리싱 완료

---

### ✨ Description
홈 페이지 퍼블리싱 완료했습니다.

https://github.com/2024-Team-Techeer-Salon/Moitda-Frontend/assets/133188752/1290c065-a092-461e-ba46-ac7ca8357ef7

- Daisy Ui 세팅
daisy ui 세팅했습니다. 추후에 MUI 라이브러리 제거 예정!

- footer 추가
footer 추가했습니다. 디자인은 그냥 임시로 대충 해놨습니다.

- ignorePath파일 추가
header, footer는 특정 URL에서는 안보여야 하기 때문에 안보여야 하는 경로 추가했습니다. header, footer 두 파일 다 수정해야하는 번거로움을 해결하기 위해 ignorePath파일을 만들었습니다.

- postComponent 파일 추가
공용 컴포넌트인 모임(게시글) 컴포넌트 제작했습니다. props로 titleImage(썸네일 이미지 링크), title(제목), location(지역), like(좋아요 수)를 받으면 됩니당

- 카카오맵 라이브러리 추가
지도를 통한 거리를 보기 위해 카카오맵 API 연동했습니다. 라이브러리 추가해놨습니다~

- .env파일 추가
.env파일을 추가했고 gitignore파일에 추가했습니다. .env파일에는 카카오맵 키가 들어있어서 깃허브에 업로드 할 수 없으므로 gitignore에 두었습니다. .env파일은 노션에 프론트엔드 페이지에 있습니다. 루트 디렉토리에 .env파일을 추가하시면 됩니다! 


<!-- write down the work details and show the execution results. -->

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #9 
