### PR TITLE
[design] 채팅 페이지 퍼블리싱 완료

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,20 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  images: {
-    domains: ['i.ibb.co'],
-  },
+// ES Module syntax
+export const images = {
+  domains: ['i.ibb.co'],
 };
 
-export default nextConfig;
+export async function redirects() {
+  return [
+    {
+      source: '/',
+      destination: '/home',
+      permanent: true,
+    },
+  ];
+}
+
+export default {
+  images,
+  redirects,
+};

--- a/src/app/chat/ChatList.tsx
+++ b/src/app/chat/ChatList.tsx
@@ -1,0 +1,106 @@
+import Image from 'next/image';
+import { chatListProps } from '@/types/chat.ts';
+
+// 마지막 채팅 시간을 문자열로 변환하는 함수 ( "yyyy-MM-dd HH:mm:ss" 형식의 문자열을 입력받음 )
+function lastTimeStr(lastTime: any) {
+  const lastTimeDate = new Date(lastTime);
+  const now = new Date();
+
+  const differenceInMinutes = Math.floor(
+    (now.getTime() - lastTimeDate.getTime()) / (1000 * 60),
+  );
+
+  if (differenceInMinutes < 60) {
+    return `${differenceInMinutes}분 전`;
+  }
+
+  const differenceInHours = Math.floor(differenceInMinutes / 60);
+  if (differenceInHours < 24) {
+    return `${differenceInHours}시간 전`;
+  }
+
+  const differenceInDays = Math.floor(differenceInHours / 24);
+  return `${differenceInDays}일 전`;
+}
+
+function unreadCountStr(unreadCount: number) {
+  if (unreadCount < 100) {
+    return unreadCount;
+  }
+  return '99+';
+}
+
+function ChatElement({
+  titleImage,
+  title,
+  peopleCount,
+  lastTime,
+  lastChat,
+  unreadCount,
+}: chatListProps) {
+  return (
+    <div className="flex w-full cursor-pointer flex-row items-center justify-start p-2 hover:bg-zinc-50">
+      {/* 대표 이미지 */}
+      <div className="m-2 flex h-12 w-12">
+        <Image
+          src={titleImage}
+          width={1024}
+          height={1024}
+          alt="profile"
+          className="relative rounded-full object-cover"
+        />
+      </div>
+
+      <div className="m-2 flex h-full w-2/3 flex-col items-start justify-center">
+        <div className="mb-2 flex w-full items-center justify-start">
+          <div className="flex w-2/3 items-center justify-start">
+            <span className="text-l truncate font-bold">{title}</span>
+            <span className="text-md ml-2 text-zinc-400">{peopleCount}</span>
+          </div>
+          <div className="ml-2 flex w-1/3 justify-end text-right text-sm text-zinc-400">
+            {lastTimeStr(lastTime)}
+          </div>
+        </div>
+        <div className="flex w-full items-center justify-start">
+          <span className="flex w-5/6 text-zinc-400">{lastChat}</span>
+          <span className="ml-2 flex h-6 w-6 items-center justify-center rounded-full bg-black text-[10px] text-white">
+            {unreadCountStr(unreadCount)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChatList() {
+  return (
+    <div className="flex h-full w-full flex-col items-start justify-start">
+      <ChatElement
+        titleImage="https://i.ibb.co/0GtvPDT/Kakao-Talk-Photo-2024-04-17-21-26-58.jpg"
+        title="모각코 할 사람!"
+        peopleCount={3}
+        lastTime="2024-05-04 18:00:58"
+        lastChat="그럼 그 때 봬요!"
+        unreadCount={1}
+      />
+      <ChatElement
+        titleImage="https://i.ibb.co/0GtvPDT/Kakao-Talk-Photo-2024-04-17-21-26-58.jpg"
+        title="새로 나온 와퍼 먹으러 가 볼 사람"
+        peopleCount={3}
+        lastTime="2024-05-03 18:00:58"
+        lastChat="그럼 그 때 봬요!"
+        unreadCount={62}
+      />
+      <ChatElement
+        titleImage="https://i.ibb.co/0GtvPDT/Kakao-Talk-Photo-2024-04-17-21-26-58.jpg"
+        title="모각코 할 사람!"
+        peopleCount={3}
+        lastTime="2024-05-02 18:00:58"
+        lastChat="그럼 그 때 봬요!"
+        unreadCount={990}
+      />
+    </div>
+  );
+}
+
+export default ChatList;

--- a/src/app/chat/ChatList.tsx
+++ b/src/app/chat/ChatList.tsx
@@ -85,15 +85,15 @@ function ChatList() {
         peopleCount={3}
         lastTime="2024-05-04 18:00:58"
         lastChat="그럼 그 때 봬요!"
-        unreadCount={1}
+        unreadCount={13}
       />
       <ChatElement
         titleImage="https://i.ibb.co/556bLCN/image.png"
         title="새로 나온 와퍼 먹으러 가 볼 사람"
-        peopleCount={8}
+        peopleCount={2}
         lastTime="2024-05-03 18:00:58"
-        lastChat="후추가 좀 더 있었으면 좋겠다 향이 조금 아쉬워"
-        unreadCount={62}
+        lastChat="후추가 좀 더 있었으면 좋겠어요. 향이 조금 약한게 아쉽네요 ㅠㅠ"
+        unreadCount={3}
       />
       <ChatElement
         titleImage="https://i.ibb.co/KDg6p1L/image.png"

--- a/src/app/chat/ChatList.tsx
+++ b/src/app/chat/ChatList.tsx
@@ -39,9 +39,9 @@ function ChatElement({
   unreadCount,
 }: chatListProps) {
   return (
-    <div className="flex w-full cursor-pointer flex-row items-center justify-start p-2 hover:bg-zinc-50">
+    <div className="flex w-full cursor-pointer flex-row items-center justify-center py-2 hover:bg-zinc-50">
       {/* 대표 이미지 */}
-      <div className="m-2 flex h-12 w-12">
+      <div className="m-4 flex h-12 w-12">
         <Image
           src={titleImage}
           width={1024}
@@ -51,19 +51,23 @@ function ChatElement({
         />
       </div>
 
-      <div className="m-2 flex h-full w-2/3 flex-col items-start justify-center">
+      {/* 채팅방 정보 */}
+      <div className="flex h-full w-2/3 flex-col items-start justify-center p-2">
+        {/* 정보 윗 줄 : 채팅방 이름, 인원수, 시간 */}
         <div className="mb-2 flex w-full items-center justify-start">
           <div className="flex w-2/3 items-center justify-start">
             <span className="text-l truncate font-bold">{title}</span>
             <span className="text-md ml-2 text-zinc-400">{peopleCount}</span>
           </div>
-          <div className="ml-2 flex w-1/3 justify-end text-right text-sm text-zinc-400">
+          <div className="flex w-1/3 justify-end p-2 text-right text-sm text-zinc-400">
             {lastTimeStr(lastTime)}
           </div>
         </div>
+
+        {/* 정보 아랫 줄 : 마지막 채팅, 안 읽은 채팅 수 */}
         <div className="flex w-full items-center justify-start">
-          <span className="flex w-5/6 text-zinc-400">{lastChat}</span>
-          <span className="ml-2 flex h-6 w-6 items-center justify-center rounded-full bg-black text-[10px] text-white">
+          <span className="w-5/6 truncate pr-8 text-zinc-400">{lastChat}</span>
+          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-black text-[10px] text-white">
             {unreadCountStr(unreadCount)}
           </span>
         </div>
@@ -84,19 +88,19 @@ function ChatList() {
         unreadCount={1}
       />
       <ChatElement
-        titleImage="https://i.ibb.co/0GtvPDT/Kakao-Talk-Photo-2024-04-17-21-26-58.jpg"
+        titleImage="https://i.ibb.co/556bLCN/image.png"
         title="새로 나온 와퍼 먹으러 가 볼 사람"
-        peopleCount={3}
+        peopleCount={8}
         lastTime="2024-05-03 18:00:58"
-        lastChat="그럼 그 때 봬요!"
+        lastChat="후추가 좀 더 있었으면 좋겠다 향이 조금 아쉬워"
         unreadCount={62}
       />
       <ChatElement
-        titleImage="https://i.ibb.co/0GtvPDT/Kakao-Talk-Photo-2024-04-17-21-26-58.jpg"
-        title="모각코 할 사람!"
-        peopleCount={3}
+        titleImage="https://i.ibb.co/KDg6p1L/image.png"
+        title="배드민턴 치러갈 사람"
+        peopleCount={16}
         lastTime="2024-05-02 18:00:58"
-        lastChat="그럼 그 때 봬요!"
+        lastChat="자리는 어떡하죠?"
         unreadCount={990}
       />
     </div>

--- a/src/app/chat/ChatWindow.tsx
+++ b/src/app/chat/ChatWindow.tsx
@@ -1,7 +1,230 @@
-import React from 'react';
+import { chatProps } from '@/types/chat.ts';
+import Image from 'next/image';
+
+function unreaderCountStr(unreaderCount: number) {
+  if (unreaderCount < 100) {
+    if (unreaderCount === 0) {
+      return '';
+    }
+    return unreaderCount;
+  }
+  return '99+';
+}
+
+function timeStr(time: string) {
+  return time.slice(11, 16);
+}
+
+// 채팅창 내 나의 채팅
+function MyChat({ time, chat, unreaderCount }: chatProps) {
+  return (
+    <div className="flex w-full flex-row items-end justify-end">
+      {/* 채팅 내용 */}
+      <div className="mt-2 flex h-full w-2/3 flex-col items-end justify-center p-2">
+        {/* 채팅 내용 */}
+        <div className="flex w-full flex-row items-center justify-end">
+          <div className="mr-2 flex flex-col items-end justify-end">
+            <span className="mr-2 text-sm text-zinc-400">
+              {unreaderCountStr(unreaderCount)}&nbsp;
+            </span>
+            <span className="mr-2 text-sm text-zinc-200">{timeStr(time)}</span>
+          </div>
+          <span className="flex items-center justify-end rounded-2xl bg-black px-4 py-3 text-white">
+            {chat}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// 채팅창 내 상대방 채팅
+function OpponentChat({
+  profileImage,
+  name,
+  time,
+  chat,
+  unreaderCount,
+}: chatProps) {
+  return (
+    <div className="flex w-full flex-row items-start justify-start">
+      {/* 프로필 사진 */}
+      <div className="m-4 flex h-12 w-12">
+        <Image
+          src={profileImage}
+          width={1024}
+          height={1024}
+          alt="profile"
+          className="relative rounded-2xl border border-zinc-50 object-cover"
+        />
+      </div>
+
+      {/* 채팅 내용 */}
+      <div className="mt-2 flex h-full w-2/3 flex-col items-start justify-center p-2">
+        <span className="text-l flex w-full items-center justify-start font-bold">
+          {name}
+        </span>
+        {/* 채팅 내용 */}
+        <div className="flex w-full flex-row items-center justify-start">
+          <span className="flex items-center justify-start rounded-2xl bg-zinc-100 px-4 py-3">
+            {chat}
+          </span>
+          <div className="ml-2 flex flex-col items-start justify-start">
+            <span className="ml-2 text-sm text-zinc-400">
+              {unreaderCountStr(unreaderCount)}&nbsp;
+            </span>
+            <span className="ml-2 text-sm text-zinc-200">{timeStr(time)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DateDivider({ date }: { date: string }) {
+  return (
+    <div className="flex w-full flex-row items-center justify-center">
+      <span className="flex w-5/12 border-b border-zinc-200"></span>
+      <span className="flex w-1/12 justify-center bg-white text-zinc-200">
+        {date.slice(0, 10)}
+      </span>
+      <span className="flex w-5/12 border-b border-zinc-200"></span>
+    </div>
+  );
+}
 
 function ChatWindow() {
-  return <div></div>;
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center">
+      {/* 채팅창 헤더 */}
+      <div className="flex h-16 w-full flex-row items-center justify-center border-b border-zinc-200 text-xl">
+        <span className="font-bold">새로 나온 와퍼 먹으러 갈 사람?</span>
+        <span className="text-md ml-2 text-zinc-200">2</span>
+      </div>
+
+      {/* 채팅창 */}
+      <div className="hide-scrollbar flex h-full w-full flex-col-reverse items-center justify-start overflow-y-auto pt-2">
+        <OpponentChat
+          profileImage="https://i.ibb.co/7CTsFJF/image.png"
+          name="정유진"
+          time="2024-05-04 19:55:00"
+          chat="후추가 좀 더 있었으면 좋겠어요. 향이 조금 약한게 아쉽네요 ㅠㅠ"
+          unreaderCount={1}
+        />
+        <OpponentChat
+          profileImage="https://i.ibb.co/7CTsFJF/image.png"
+          name="정유진"
+          time="2024-05-04 19:55:00"
+          chat="그런데"
+          unreaderCount={1}
+        />
+        <OpponentChat
+          profileImage="https://i.ibb.co/7CTsFJF/image.png"
+          name="정유진"
+          time="2024-05-04 19:54:00"
+          chat="확실히 맛있었어요!"
+          unreaderCount={1}
+        />
+        <MyChat
+          time="2024-05-04 19:53:00"
+          chat="맛은 어떠셨어요??"
+          unreaderCount={0}
+          profileImage={''}
+          name={''}
+        />
+        <MyChat
+          time="2024-05-04 19:52:00"
+          chat="네 잘 들어왔습니다!"
+          unreaderCount={0}
+          profileImage={''}
+          name={''}
+        />
+        <OpponentChat
+          profileImage="https://i.ibb.co/7CTsFJF/image.png"
+          name="정유진"
+          time="2024-05-04 19:50:00"
+          chat="잘 들어가셨나요?"
+          unreaderCount={0}
+        />
+        <OpponentChat
+          profileImage="https://i.ibb.co/7CTsFJF/image.png"
+          name="정유진"
+          time="2024-05-04 19:35:00"
+          chat="아 잘 먹었네요"
+          unreaderCount={0}
+        />
+        <OpponentChat
+          profileImage="https://i.ibb.co/7CTsFJF/image.png"
+          name="정유진"
+          time="2024-05-04 18:05:30"
+          chat="좀 이따가 뵈어요!"
+          unreaderCount={0}
+        />
+        <OpponentChat
+          profileImage="https://i.ibb.co/7CTsFJF/image.png"
+          name="정유진"
+          time="2024-05-04 18:05:00"
+          chat="네 그러면 지금 바로 나갈게요!"
+          unreaderCount={0}
+        />
+        <MyChat
+          time="2024-05-04 18:04:30"
+          chat="네 괜찮습니다! 버거킹 송죽 DT점에서 만날까요?"
+          unreaderCount={0}
+          profileImage={''}
+          name={''}
+        />
+        <OpponentChat
+          profileImage="https://i.ibb.co/7CTsFJF/image.png"
+          name="정유진"
+          time="2024-05-04 18:04:00"
+          chat="딱 저녁시간이네요!"
+          unreaderCount={0}
+        />
+        <OpponentChat
+          profileImage="https://i.ibb.co/7CTsFJF/image.png"
+          name="정유진"
+          time="2024-05-04 18:03:30"
+          chat="그럼 지금 혹시 시간 괜찮으신가요?"
+          unreaderCount={0}
+        />
+        <MyChat
+          time="2024-05-04 18:02:58"
+          chat="네 좋아요!"
+          unreaderCount={0}
+          profileImage={''}
+          name={''}
+        />
+        <OpponentChat
+          profileImage="https://i.ibb.co/7CTsFJF/image.png"
+          name="정유진"
+          time="2024-05-04 18:00:58"
+          chat="이번에 버거킹에서 와퍼 새로 나왔대요! 그래서 먹어보고 싶은데 혹시 같이 가실래요?"
+          unreaderCount={0}
+        />
+        <OpponentChat
+          profileImage="https://i.ibb.co/7CTsFJF/image.png"
+          name="정유진"
+          time="2024-05-04 18:00:58"
+          chat="안녕하세요! 반갑습니다!"
+          unreaderCount={0}
+        />
+        <DateDivider date="2024-05-04" />
+      </div>
+
+      {/* 채팅 입력창 */}
+      <div className="m-2 flex h-52 w-[99%] flex-col items-end justify-start rounded-2xl border border-zinc-200">
+        <input
+          type="text"
+          placeholder="메시지를 입력하세요"
+          className="text-md flex h-3/5 w-full flex-wrap items-center justify-start rounded-full px-4 focus:outline-none"
+        />
+        <button className="m-4 h-8 w-20 rounded-lg bg-black text-white">
+          전송
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export default ChatWindow;

--- a/src/app/chat/ChatWindow.tsx
+++ b/src/app/chat/ChatWindow.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function ChatWindow() {
+  return <div></div>;
+}
+
+export default ChatWindow;

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,20 @@
+import ChatList from './ChatList.tsx';
+import ChatWindow from './ChatWindow.tsx';
+
+function page() {
+  return (
+    <div
+      className="absolute flex w-full flex-row items-center justify-center overflow-y-hidden"
+      style={{ height: 'calc(100% - 5rem)' }} // 채팅창 높이 = 전체 높이 - 헤더 높이(5rem)
+    >
+      <div className="fix flex h-full w-96 flex-col items-center justify-start border border-r-0 border-zinc-200">
+        <ChatList />
+      </div>
+      <div className="fix flex h-full w-full flex-col items-center justify-start border border-r-0 border-zinc-200">
+        <ChatWindow />
+      </div>
+    </div>
+  );
+}
+
+export default page;

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -8,7 +8,7 @@ const mont = Montserrat({ subsets: ['latin'], weight: ['500'] });
 
 function Footer() {
   const path = usePathname();
-  if (ignorePath().includes(path)) {
+  if (ignorePath().includes(path) || path === '/chat') {
     return null;
   }
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,9 @@
-// 메인 페이지 컴포넌트
+'use server';
 
-'use client';
+import { redirect } from 'next/navigation';
 
-import Link from 'next/link';
-
-function Home() {
-  return (
-    <div className="flex flex-col w-full h-screen">
-      <h1 className="text-2xl">Moitda 프로젝트입니다.</h1>
-      <Link className="text-blue-600" href="/home">
-        home으로 가기
-      </Link>
-    </div>
-  );
+export default function page() {
+  redirect('/home');
+  // permanentRedirect('/home');
+  return <div>Redirecting...</div>;
 }
-
-export default Home;

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -4,7 +4,7 @@
 
 /* 웹킷(Chrome, Safari 등) 브라우저의 스크롤바 */
 ::-webkit-scrollbar {
-  width: 0.5rem; /* 스크롤바의 너비 */
+  width: 0.4rem; /* 스크롤바의 너비 */
 }
 
 /* 스크롤바의 Track (배경) */
@@ -24,4 +24,7 @@
 }
 body {
   background-color: #ffffff;
+}
+.hide-scrollbar {
+  scrollbar-width: none; /* Firefox */
 }

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -6,3 +6,11 @@ export interface chatListProps {
   lastChat: string; // 마지막 채팅 내용
   unreadCount: number; // 읽지 않은 메시지 수
 }
+
+export interface chatProps {
+  profileImage: string; // 프로필 이미지 URL
+  name: string; // 이름
+  time: string; // 시간
+  chat: string; // 채팅 내용
+  unreaderCount: number; // 읽지 않은 사람 수
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,8 @@
+export interface chatListProps {
+  titleImage: string; // 채팅방 이미지 URL
+  title: string; // 채팅방 제목
+  peopleCount: number; // 채팅방 인원 수
+  lastTime: string; // 마지막 채팅 시간
+  lastChat: string; // 마지막 채팅 내용
+  unreadCount: number; // 읽지 않은 메시지 수
+}


### PR DESCRIPTION
### 🚀 Summary
채팅 페이지 퍼블리싱 완료
<!-- A brief description of the issue. -->

---

### ✨ Description
채팅 페이지 퍼블리싱 완료했습니다.

<!-- write down the work details and show the execution results. -->

https://github.com/2024-Team-Techeer-Salon/Moitda-Frontend/assets/133188752/0f7d44c3-eb9c-4281-954b-6a3a58f4f996

그 외에 채팅창은 footer가 보이지 않도록 설정했고 스크롤도 숨김처리 해 두었습니다.

그리고 루트 경로로 접속하면 /home 경로로 리다이렉트 되도록 next.config.mjs 파일에 코드를 수정했습니다.(서버측에서 리다이렉트 해야 클라이언트측에서 두번 렌더링이 되지 않음. 서버측에서 한번에 하는게 효율적)

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #27 
